### PR TITLE
Update mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,8 +8,8 @@ defmodule PKCS7.Mixfile do
      description: "PKCS7 binary padding for erlang",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     package: package,
-     deps: deps]
+     package: package(),
+     deps: deps()]
   end
 
   def application do


### PR DESCRIPTION
Some changes were made to avoid this kind of message: "warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name" for deps and package functions to apply configuration.